### PR TITLE
Issue #142 for github/mozilla/lightbeam-we

### DIFF
--- a/grok-web-request-urls/app.js
+++ b/grok-web-request-urls/app.js
@@ -1,0 +1,25 @@
+// NOTE: commented out for now, since I couldn't get the service worker
+// to run in the Web Extension context. I have duplicated this code (app.js and service-worker.js)
+// and hosted it over HTTPS at biancadanforth.github.io/web-request-test.
+
+// // Register the ServiceWorker
+// if ('serviceWorker' in navigator) {
+//   navigator.serviceWorker.register('service-worker.js', {
+//   scope: '.'
+//   }).then(function(registration) {
+//   console.log('The service worker has been registered ', registration);
+//   });
+// }
+
+// navigator.serviceWorker.ready.then(addIFrame);
+// const swContainer = document.getElementById('sw-container');
+// let iframe = document.createElement('iframe');
+
+// function addIFrame() {
+//   swContainer.appendChild(iframe);
+//   loadIFrame();
+// }
+
+// function loadIFrame() {
+//   iframe.src = 'third-party-doc.html';
+// }

--- a/grok-web-request-urls/background.js
+++ b/grok-web-request-urls/background.js
@@ -1,0 +1,7 @@
+'use strict';
+
+runApp();
+
+async function runApp() {
+  browser.tabs.create({url: 'index.html'});
+}

--- a/grok-web-request-urls/capture.js
+++ b/grok-web-request-urls/capture.js
@@ -1,0 +1,148 @@
+/*
+* Listens for HTTP request responses, sending first- and
+* third-party requests to storage.
+*/
+const capture = {
+
+  init() {
+    this.addListeners();
+  },
+
+  addListeners() {
+    // listen for each HTTP response
+    this.queue = [];
+    browser.webRequest.onResponseStarted.addListener((response) => {
+      const eventDetails = {
+        type: 'sendThirdParty',
+        data: response
+      };
+      this.queue.push(eventDetails);
+      this.processNextEvent();
+    },
+      {urls: ['<all_urls>']});
+    // listen for tab updates
+    browser.tabs.onUpdated.addListener(
+      (tabId, changeInfo, tab) => {
+        const eventDetails = {
+          type: 'sendFirstParty',
+          data: {
+            tabId,
+            changeInfo,
+            tab
+          }
+        };
+        this.queue.push(eventDetails);
+        this.processNextEvent();
+      });
+  },
+
+  // Process each HTTP request or tab page load in order,
+  // so that async reads/writes to IndexedDB
+  // (via sendFirstParty and sendThirdParty) won't miss data
+  // The 'ignore' boolean ensures processNextEvent is only
+  // executed when the previous call to processNextEvent
+  // has completed.
+  async processNextEvent(ignore = false) {
+    if (this.processingQueue && !ignore) {
+      return;
+    }
+    if (this.queue.length >= 1) {
+      const nextEvent = this.queue.shift();
+      this.processingQueue = true;
+      switch (nextEvent.type) {
+        case 'sendFirstParty':
+          await this.sendFirstParty(
+            nextEvent.data.tabId,
+            nextEvent.data.changeInfo,
+            nextEvent.data.tab
+          );
+          break;
+        case 'sendThirdParty':
+          await this.sendThirdParty(nextEvent.data);
+          break;
+        default:
+          throw new Error(
+            'An event must be of type sendFirstParty or sendThirdParty.'
+          );
+      }
+      this.processNextEvent(true);
+    } else {
+      this.processingQueue = false;
+    }
+  },
+
+  // Returns true if the request should be stored, otherwise false.
+  // info could be a tab (from setFirstParty) or a
+  // response (from setThirdParty) object
+  async shouldStore(info) {
+    const tabId = info.id || info.tabId;
+    const visibleTab = tabId !== browser.tabs.TAB_ID_NONE;
+    let tab, documentUrl, privateBrowsing;
+    if (visibleTab) {
+      tab = await browser.tabs.get(tabId);
+      documentUrl = new URL(tab.url);
+      privateBrowsing = tab.incognito;
+    } else {
+      // browser.tabs.get throws an error for nonvisible tabs (tabId = -1)
+      // but some non-visible tabs can make third party requests,
+      // ex: Service Workers
+      documentUrl = new URL(info.documentUrl);
+      privateBrowsing = false;
+    }
+    // ignore about:*, moz-extension:*
+    // also ignore private browsing tabs
+    if (documentUrl.protocol !== 'about:'
+      && documentUrl.protocol !== 'moz-extension:'
+      && !privateBrowsing) {
+      return true;
+    }
+    return false;
+  },
+
+  // capture third party requests
+  async sendThirdParty(response) {
+
+    if (!response.documentUrl) {
+      // documentUrl is undefined for the first request from the browser to the
+      // first party site
+      return;
+    }
+
+    // @todo figure out why Web Extensions sometimes gives
+    // undefined for response.originUrl
+    const originUrl = response.originUrl ? new URL(response.originUrl) : '';
+    const documentUrl = new URL(response.documentUrl);
+    const targetUrl = new URL(response.url);
+
+    if (targetUrl.hostname !== documentUrl.hostname
+      && await this.shouldStore(response)) {
+      const data = {
+        document: documentUrl.hostname,
+        target: targetUrl.hostname,
+        origin: originUrl.hostname,
+        requestTime: response.timeStamp,
+        firstParty: false
+      };
+      console.log(data);
+      // await store.setThirdParty(
+      //   documentUrl.hostname,
+      //   targetUrl.hostname,
+      //   data
+      // );
+    }
+  },
+
+  // capture first party requests
+  async sendFirstParty(tabId, changeInfo, tab) {
+    const documentUrl = new URL(tab.url);
+    if (tab.status === 'complete' && await this.shouldStore(tab)) {
+      const data = {
+        faviconUrl: tab.favIconUrl,
+        firstParty: true
+      };
+      // await store.setFirstParty(documentUrl.hostname, data);
+    }
+  }
+};
+
+capture.init();

--- a/grok-web-request-urls/index.html
+++ b/grok-web-request-urls/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
+    <title>What do different URLs refer to from the webRequest WebExtension API</title>
+    <meta name="description" content="The webRequest.onResponseStarted event returns a response object with HTTP request details, including a key for documentUrl, targetUrl and originUrl. The purpose of this experiment is to find out what each means in a lot of different scenarios.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <h1>Motivation</h1>
+    <p>The webRequest.onResponseStarted event returns a response object with HTTP request details, including a key for documentUrl, targetUrl and originUrl. The purpose of this experiment is to find out what each means in a lot of different scenarios..</p>
+    <h2>Instructions</h2>
+    <p>To see the results for the experiments on this page, open the browser console (Ctrl/Cmd + Shift + J) and filter results for 'capture'. Scenarios 1-4 are readily viewable in the console upon running the web extension (I use the <a href="https://github.com/mozilla/web-ext">web-ext</a> CLI). For Scenario 5 results, load <a href="https://biancadanforth.github.io/web-request-test/">this page</a> and view the console.</p>
+    <h2>Important</h2>
+    <p>These requests represent only what is *captured* by the current capture code for <a href="https://github.com/mozilla/lightbeam-we">Lightbeam</a>. See <a href="https://github.com/biancadanforth/web-dev-experiments/grok-web-request-urls/">this repo's</a> <code>capture.js</code> file for that.</p>
+    <hr>
+    <section>
+      <h2>Scenario 1: an <code>iframe</code> pointing to a different webpage</h2>
+      <h3>Open <a href="https://biancadanforth.github.io/web-request-test/scenario-1.html" target="_blank">Scenario 1</a></h3>
+    </section>
+    <section>
+      <h2>Scenario 2: an <code>iframe</code> loads a script</h2>
+      <h3>Open <a href="https://biancadanforth.github.io/web-request-test/scenario-2.html" target="_blank">Scenario 2</a></h3>
+    </section>
+    <section>
+      <h2>Scenario 3: an <code>iframe</code> loads an image</h2>
+      <h3>Open <a href="https://biancadanforth.github.io/web-request-test/scenario-3.html" target="_blank">Scenario 3</a></h3>
+    </section>
+    <section>
+      <h2>Scenario 4: A chain of <code>iframe</code>s, each loading a separate and distinct third party resource (an HTML document in this case).</h2>
+      <h3>Open <a href="http://biancadanforth.com/web-request-test/scenario-4.html" target="_blank">Scenario 4</a></h3>
+    </section>
+    <section>
+      <h2>Scenario 5: A service worker is used.</h2>
+      <h3>Open <a href="https://biancadanforth.github.io/web-request-test/scenario-5.html" target="_blank">Scenario 5</a></h3>
+    </section>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/grok-web-request-urls/manifest.json
+++ b/grok-web-request-urls/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 2,
+  "name": "webRequest experiment",
+  "version": "1.0",
+
+  "description": "The webRequest.onResponseStarted event returns a response object with HTTP request details, including a key for documentUrl, targetUrl and originUrl. The purpose of this experiment is to find out what each means in a lot of different scenarios.",
+  "homepage_url": "https://github.com/biancadanforth/web-ext-experiments",
+
+  "permissions": [
+    "webRequest",
+    "<all_urls>",
+    "tabs"
+  ],
+
+  "background": {
+    "scripts": [
+      "background.js",
+      "capture.js"
+    ]
+  }
+}

--- a/grok-web-request-urls/service-worker.js
+++ b/grok-web-request-urls/service-worker.js
@@ -1,0 +1,47 @@
+// based on: https://serviceworke.rs/strategy-network-or-cache_service-worker_doc.html
+
+let CACHE = 'network-first';
+
+self.addEventListener('install', function(evt) {
+  console.log('The service worker is being installed.');
+  evt.waitUntil(precache());
+});
+
+self.addEventListener('fetch', function(evt) {
+  console.log('The service worker is serving the asset.');
+  evt.respondWith(fromNetwork(evt.request, 400)
+    .catch(function() {
+      return fromCache(evt.request);
+    }));
+});
+
+self.addEventListener('activate', function() {
+
+});
+
+function precache() {
+  return caches.open(CACHE).then(function(cache) {
+    console.log('Opened cache');
+    return cache.addAll([
+      'third-party-doc.html'
+      ]);
+  });
+}
+
+function fromNetwork(request, timeout) {
+  return new Promise(function(fulfill, reject) {
+    const timeoutId = setTimeout(reject, timeout);
+    fetch(request).then(function(response) {
+      clearTimeout(timeoutId);
+      fulfill(response);
+    }, reject);
+  });
+}
+
+function fromCache(request) {
+  return caches.open(CACHE).then(function(cache) {
+    return cache.match(request).then(function(matching) {
+      return matching || Promise.reject('no-match');
+    });
+  });
+}

--- a/grok-web-request-urls/third-party-doc.html
+++ b/grok-web-request-urls/third-party-doc.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
+    <title>A document loaded by service-worker.js to load a third party resource</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+   <img src="https://assets-cdn.github.com/images/modules/site/universe-logo.png">
+  </body>
+</html>


### PR DESCRIPTION
Using Mozilla's Web Extension API (the webRequest one), the webRequest.onResponseStarted event returns a response object with HTTP request details, including a key for documentUrl, targetUrl and originUrl. The purpose of this experiment is to find out what each means in a lot of different scenarios.

Trying to answer some questions from this PR:
https://github.com/electrolyfish/lightbeam-we/pull/115